### PR TITLE
Adding master list of ERDDAPs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,6 @@
-# Contribution
+# Contributing
+
+## Contributing to the Awesome List
 
 Please ensure your pull request adheres to the following guidelines:
 
@@ -11,3 +13,13 @@ Please ensure your pull request adheres to the following guidelines:
 - Make sure your text editor is set to remove trailing whitespace.
 
 Thank you for your suggestions! <3
+
+## Contributing to the Erddap List JSON file
+
+Please ensure your pull request adheres to the following guidelines:
+
+- Search the JSON object to make sure you're not duplicating existing entries
+- The JSON file is an array of objects. Add a new object for your server
+- Ensure you've added a name and a url attribute to your object. No more and no less
+- Check the url is correct with respect to http:// or https://
+- Please validate your JSON object against the [schema](/json-schema/ErddapInstancesSchema.json) using a tool such as [this one](https://www.jsonschemavalidator.net/).

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Inspired by [Bob Simons](https://github.com/BobSimons) and the [awesome](https:/
 
 ## ERDDAP
 - The [ERDDAP data server](https://github.com/BobSimons/erddap) itself - various instances power all the awesome projects on this list
+- [List of ERDDAP instances](erddaps.json) - A JSON file of ERDDAP instances for use in applications which require access to multiple ERDDAP servers. This file is hosted within this repository. To add your ERDDAP server to the JSON file, please see the [guidelines for contributing](CONTRIBUTING.md).
 
 ## ERDDAP Clients
 - [erddapy](https://pyoceans.github.io/erddapy) - Python language package for simplified access to ERDDAP servers.
@@ -24,7 +25,7 @@ Inspired by [Bob Simons](https://github.com/BobSimons) and the [awesome](https:/
 - [rerddapXtracto](https://github.com/rmendels/rerddapXtracto) - R language package that uses rerdddap to extract data from ERDDAP servers along a trajectory or inside a polygon.
 
 ## ArcGIS
-- [Environmental Data Connector](http://asascience.com/software/downloads/) - The Environmental Data Connector (EDC) extension uses a Java-based browser to allow users to connect to THREDDS/SOS/ERDDAP data servers. The connector leverages existing components from the Unidata libraries so that users can filter large amounts of data in space and time. The data and metadata can automatically be loaded into ArcMap, R, Matlab, or Excel..
+- [Environmental Data Connector](http://asascience.com/software/downloads/) - The Environmental Data Connector (EDC) extension uses a Java-based browser to allow users to connect to THREDDS/SOS/ERDDAP data servers. The connector leverages existing components from the Unidata libraries so that users can filter large amounts of data in space and time. The data and metadata can automatically be loaded into ArcMap, R, Matlab, or Excel.
 
 ## Web Mapping Services
 - [timeliER](https://irishmarineinstitute.github.io/timeliER/#IMI_CONN_3D) - Smooth playing of ERDDAP WMS data using [LeafletTime.Dimension](https://github.com/socib/Leaflet.TimeDimension) 

--- a/erddaps.json
+++ b/erddaps.json
@@ -1,0 +1,142 @@
+[
+	{
+		"name": "CoastWatch West Coast Node",
+		"url": "https://coastwatch.pfeg.noaa.gov/erddap/"
+	},
+    {
+		"name": "ERDDAP at the Asia-Pacific Data-Research Center",
+		"url": "https://apdrc.soest.hawaii.edu/erddap/"
+	},
+    {
+		"name": "NOAA's National Centers for Environmental Information (NCEI)",
+		"url": "https://www.ncei.noaa.gov/erddap/"
+	},
+    {
+		"name": "Biological and Chemical Oceanography Data Management Office (BCO-DMO) ERDDAP",
+		"url": "https://erddap.bco-dmo.org/erddap/"
+	},
+    {
+		"name": "European Marine Observation and Data Network (EMODnet) Physics ERDDAP",
+		"url": "https://erddap.emodnet-physics.eu/erddap/"
+	},
+    {
+		"name": "Marine Institute - Ireland",
+		"url": "https://erddap.marine.ie/erddap/"
+	},
+    {
+		"name": "CoastWatch Caribbean/Gulf of Mexico Node",
+		"url": "https://cwcgom.aoml.noaa.gov/erddap/"
+	},
+    {
+		"name": "NOAA IOOS Sensors ERDDAP",
+		"url": "http://erddap.sensors.ioos.us/erddap/"
+	},
+    {
+		"name": "NOAA IOOS CeNCOOS (Central and Northern California Ocean Observing System)",
+		"url": "http://erddap.axiomdatascience.com/erddap/"
+	},
+    {
+		"name": "NOAA IOOS NERACOOS (Northeastern Regional Association of Coastal and Ocean Observing Systems)",
+		"url": "http://www.neracoos.org/erddap/"
+	},
+    {
+		"name": "NOAA IOOS NGDAC (National Glider Data Assembly Center)",
+		"url": "https://data.ioos.us/gliders/erddap/"
+	},
+    {
+		"name": "NOAA IOOS PacIOOS (Pacific Islands Ocean Observing System) at the University of Hawaii (UH)",
+		"url": "http://oos.soest.hawaii.edu/erddap/"
+	},
+    {
+		"name": "Southern California Coastal Ocean Observing System (SCCOOS)",
+		"url": "http://sccoos.org/erddap/"
+	},
+    {
+		"name": "NOAA IOOS SECOORA (Southeast Coastal Ocean Observing Regional Association)",
+		"url": "http://erddap.secoora.org/erddap/"
+	},
+    {
+		"name": "NOAA NCEI (National Centers for Environmental Information) / NCDDC",
+		"url": "https://ecowatch.ncddc.noaa.gov/erddap/"
+	},
+    {
+		"name": "NOAA OSMC (Observing System Monitoring Center)",
+		"url": "http://osmc.noaa.gov/erddap/"
+	},
+    {
+		"name": "ONC (Ocean Networks Canada)",
+		"url": "http://dap.onc.uvic.ca/erddap/"
+	},
+    {
+		"name": "",
+		"url": "https://oceanwatch.pifsc.noaa.gov/erddap/"
+	},
+    {
+		"name": "Ocean Observatories Initiative (OOI)",
+		"url": "https://erddap-uncabled.oceanobservatories.org/uncabled/erddap/"
+	},
+    {
+		"name": "Ocean Tracking Network",
+		"url": "https://members.oceantrack.org/erddap/"
+	},
+    {
+		"name": "",
+		"url": "http://www.myroms.org:8080/erddap/"
+	},
+    {
+		"name": "Department of Marine and Coastal Sciences, School of Environmental and Biological Sciences, Rutgers, The State University of New Jersey",
+		"url": "http://tds.marine.rutgers.edu/erddap/"
+	},
+    {
+		"name": "",
+		"url": "https://comet.nefsc.noaa.gov/erddap/"
+	},
+    {
+		"name": "NOAA's Center for Operational Oceanographic Products and Services",
+		"url": "https://opendap.co-ops.nos.noaa.gov/erddap/"
+	},
+    {
+		"name": "",
+		"url": "http://gcoos5.geos.tamu.edu:6060/erddap/"
+	},
+    {
+		"name": "",
+		"url": "http://gcoos4.tamu.edu:8080/erddap/"
+	},
+    {
+		"name": "NOAA CoastWatch Great Lakes Node",
+		"url": "https://coastwatch.glerl.noaa.gov/erddap/"
+	},
+    {
+		"name": "",
+		"url": "http://sfbaynutrients.sfei.org/erddap/"
+	},
+    {
+		"name": "Spray Underwater Glider data from Instrument Development Group, Scripps Institute of Oceanography, University of California, San Diego",
+		"url": "https://spraydata.ucsd.edu/erddap/"
+	},
+    {
+		"name": "UBC Earth, Ocean & Atmospheric Sciences SalishSeaCast Project",
+		"url": "https://salishsea.eos.ubc.ca/erddap/"
+	},
+    {
+		"name": "UC Davis BML (University of California at Davis, Bodega Marine Laboratory)",
+		"url": "http://bmlsc.ucdavis.edu:8080/erddap/"
+	},
+    {
+		"name": "NOAA UAF (Unified Access Framework)",
+		"url": "https://upwell.pfeg.noaa.gov/erddap/"
+	},
+	{
+		"name": "Marine Domain Awareness (MDA) - Italy",
+		"url": "https://bluehub.jrc.ec.europa.eu/erddap/"
+	},
+	{
+		"name": "R.Tech Engineering",
+		"url": "https://meteo.rtech.fr/erddap/"
+	},
+	{
+		"name": "French Research Institute for the Exploitation of the Sea",
+		"url": "http://www.ifremer.fr/erddap/"
+	}
+]

--- a/json-schema/ErddapInstancesSchema.json
+++ b/json-schema/ErddapInstancesSchema.json
@@ -1,0 +1,26 @@
+{
+   "$schema": "http://json-schema.org/draft-04/schema#",
+   "title": "erddap-instances",
+   "type": "array",
+   "items": {"$ref": "#/definitions/instance"},
+   "definitions":{
+	"instance":{
+		"description": "The detail needed for an Erddap instance",
+		"type": "object",
+		"properties":{
+			"name": {
+				"description": "A text label given to the Erddap instance",
+				"type": "string"
+			},
+			"url":{
+				"description": "The web address of the Erddap instance",
+				"type": "string"
+			}
+		},
+		"required": ["name", "url"],
+		"additionalProperties": false,
+		"maxProperties": 2,
+		"minProperties": 2
+	}
+   }
+}


### PR DESCRIPTION
In response to https://github.com/IrishMarineInstitute/search-erddaps/issues/4, this PR adds a JSON file which consolidates the lists used by https://github.com/BobSimons/erddap, https://github.com/ioos/erddapy, https://github.com/ropensci/rerddap and https://github.com/IrishMarineInstitute/search-erddaps

A JSON Schema to validate the JSON file is also added. This could be put into a build process at some point. A JQ to extract just the URLs for applications which need them could also be added, generating a second JSON file.