### PR TITLE
Pure JavaScript demo of ERDDAP RESTful API for plotting long time

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Inspired by [Bob Simons](https://github.com/BobSimons) and the [awesome](https:/
 - [erddapy](https://ioos.github.io/erddapy/) - Python language package for simplified access to ERDDAP servers.
 - [rerddap](https://github.com/ropensci/rerddap) - R language package for simplified access to data in any ERDDAP server, can also be installed from CRAN.
 - [rerddapXtracto](https://github.com/rmendels/rerddapXtracto) - R language package that uses rerdddap to extract data from ERDDAP servers along a trajectory or inside a polygon.
+- [erddap-highstock-viewer](https://github.com/gulfofmaine/erddap-highstock-viewer) -  Simple pure javascript example to demonstrate display of long time series in HighCharts from a CORS enabled ERDDAP RESTful API.
 
 ## ArcGIS
 


### PR DESCRIPTION
Pure Javascript demo of ERDDAP RESTful API for plotting long time series with HighCharts. This is the NERACOOS ERDDAP which has CORS enabled via Apache.  Not a library, just a simple demo of ERDDAP's and HighCharts performance.