### PR TITLE
remove https://meteo.rtech.fr/

### DIFF
--- a/erddaps.json
+++ b/erddaps.json
@@ -198,12 +198,6 @@
 		"public": true
 	},
 	{
-		"name": "R.Tech Engineering",
-		"short_name": "RTECH",
-		"url": "https://meteo.rtech.fr/erddap/",
-		"public": true
-	},
-	{
 		"name": "French Research Institute for the Exploitation of the Sea",
 		"short_name": "IFREMER",
 		"url": "https://www.ifremer.fr/erddap/",


### PR DESCRIPTION
This erddap server seems to be offline for a while. Not sure if the URL changed or if they turned it off.